### PR TITLE
Sneakerのマイグレーションファイル、migrate忘れ

### DIFF
--- a/db/migrate/20230612135609_create_sneaker_comments.rb
+++ b/db/migrate/20230612135609_create_sneaker_comments.rb
@@ -1,9 +1,9 @@
 class CreateSneakerComments < ActiveRecord::Migration[6.1]
   def change
     create_table :sneaker_comments do |t|
-      t.comment :text
-      t.user_id :integer
-      t.sneaker_id :integer
+      t.text :comment
+      t.integer:user_id 
+      t.integer :sneaker_id 
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_131544) do
+ActiveRecord::Schema.define(version: 2023_06_12_135609) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -50,6 +50,14 @@ ActiveRecord::Schema.define(version: 2023_06_12_131544) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "sneaker_comments", force: :cascade do |t|
+    t.text "comment"
+    t.integer "user_id"
+    t.integer "sneaker_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "sneakers", force: :cascade do |t|


### PR DESCRIPTION
### テーブル作成後rails db:migrateを忘れていた
- テーブルの記載方法が間違えていたため、訂正してmigrate行いました。