### PR TITLE
フォロー・フォロワー機能完成

### DIFF
--- a/app/controllers/user/relationships_controller.rb
+++ b/app/controllers/user/relationships_controller.rb
@@ -9,7 +9,7 @@ class User::RelationshipsController < ApplicationController
     
     def destroy
         user = User.find(params[:user_id])
-        current_user.follow(user)
+        current_user.unfollow(user)
         redirect_to request.referer
     end
     


### PR DESCRIPTION
###　フォロー・フォロワー機能完成
- フォローを外す機能が正常動作していなかったのは、unfollowと記載しなければいけないところをfollowと記載していたことが原因